### PR TITLE
Fix dynamic import for RealESRGAN models

### DIFF
--- a/aivis/models/realesrgan/models/__init__.py
+++ b/aivis/models/realesrgan/models/__init__.py
@@ -7,4 +7,10 @@ from os import path as osp
 model_folder = osp.dirname(osp.abspath(__file__))
 model_filenames = [osp.splitext(osp.basename(v))[0] for v in scandir(model_folder) if v.endswith('_model.py')]
 # import all the model modules
-_model_modules = [importlib.import_module(f'.{file_name}', package='realesrgan.models') for file_name in model_filenames]
+# compute the current package name dynamically
+package_name = __name__
+# import all the model modules
+_model_modules = [
+    importlib.import_module(f'.{file_name}', package=package_name)
+    for file_name in model_filenames
+]


### PR DESCRIPTION
## Summary
- make `aivis.models.realesrgan.models` resolve its own package name at runtime

## Testing
- `python - <<'PY'
import types, sys
modules=['numpy','satpy','satpy.scene','geopy','geopy.distance','torch','torch.nn','torch.nn.functional','torchvision','torchvision.transforms','skimage','skimage.transform','cv2','safetensors','safetensors.torch','basicsr','basicsr.utils','basicsr.utils.download_util','dask','dask.array']
for m in modules: sys.modules.setdefault(m, types.ModuleType(m))
sys.modules['torch'].nn=sys.modules['torch.nn']; sys.modules['torch.nn'].functional=sys.modules['torch.nn.functional']; sys.modules['torch'].no_grad=lambda:(lambda f:f)
sys.modules['satpy.scene'].Scene=type('Scene',(),{}); sys.modules['geopy.distance'].geodesic=lambda *a,**kw:None
sys.modules['basicsr.utils'].scandir=lambda folder:[]; sys.modules['basicsr.utils.download_util'].load_file_from_url=lambda *a,**kw:None
sys.modules['safetensors.torch'].load_file=lambda *a,**kw:None; sys.modules['dask.array'].array=lambda *a,**kw:None
from aivis.models.realesrgan import RealESRGANer
print('RealESRGANer imported from', RealESRGANer.__module__)
PY`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*